### PR TITLE
Fix invalid YAML for webhook URLs in .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,6 +30,6 @@ script:
 notifications:
     webhooks:
         urls:
-            -http://life.jstfy.com/hook
+            - http://life.jstfy.com/hook
         on_succes: always
         on_failure: never


### PR DESCRIPTION
Needs a space after the -, otherwise it won't be interpreted as a list.
